### PR TITLE
Add simple caching support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ dask==2.9.1
 distributed==2.9.1
 Flask==1.1.1
 Flask-Bootstrap==3.3.7.1
+Flask-Caching==1.8.0
 gcsfs==0.6.0
 intake==0.5.4
 intake-xarray==0.3.1


### PR DESCRIPTION
This adds support for a [SimpleCache](https://flask-caching.readthedocs.io/en/latest/#simplecache) with a timeout of 300 seconds. We can configure this to our needs as they come up.