### PR TITLE
Add cat.description as title

### DIFF
--- a/templates/xarray.html
+++ b/templates/xarray.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}{{ cat.description }}{% endblock %}
+
 {% block content %}
 <main role="main" class="container">
   <h1>Pangeo Catalog</h1>


### PR DESCRIPTION
Just a simple fix to add titles to the separate endpoints for xarray datasets.