### PR TITLE
Add rasterio to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ gcsfs==0.6.0
 intake==0.5.4
 intake-esm==2019.12.13
 intake-xarray==0.3.1
+rasterio==1.1.3
 xarray==0.14.1
 zarr==2.4.0


### PR DESCRIPTION
Because App Engine installs its requirements through `pip`, the approach to installing rasterio may not be as easy as including it in the `requirements.txt`; if this initial commit doesn't work, we may need to explore more complex solutions:

- Trying to access apt-get to install the dependencies prior to deploying/testing the app
- Downloading and installing the binary wheels
- Installing the package through `conda`