### PR TITLE
Fix favicon request errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,6 +94,13 @@ def parse(path):
         type, value = sys.exc_info()[:2]
         return render_template("error.html", type=type, value=value), 500
 
+      
+@app.route('/favicon.ico')
+@cache.cached()
+def favicon():
+  return redirect(url_for('static', filename='favicon.ico'))
+
+
 if __name__ == '__main__':
     app.run(host='127.0.0.1', port=8080, debug=True)
 # [START gae_python37_render_template]

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,10 +1,5 @@
 {% extends "bootstrap/base.html" %}
 
-{% block head %}
-{{ super() }}
-<link rel='icon' href="{{url_for('static', filename='favicon.ico')}}" type='image/x-icon'/ >
-{% endblock %}
-
 {% block styles %}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.7/cosmo/bootstrap.css">
 <link rel="stylesheet" href="{{url_for('static', filename='pangeo-style.css')}}">


### PR DESCRIPTION
By default, a GET request is made for `/favicon.ico`, which due to the current set up creates an error in Intake since anything added to the base URL is considered an Intake entry.

This adds a basic redirect to the favicon.ico, so that this error should no longer occur.