### PR TITLE
Fix single file catalog handling

### DIFF
--- a/templates/esmcol.html
+++ b/templates/esmcol.html
@@ -12,6 +12,15 @@
       collapsed: true,
       rootCollapsable: false
     });
+    {% if 'catalog_file' not in json %}
+    Papa.parse("{{ cat.df.to_csv(index=False, line_terminator='\\n').replace('"', '') }}", {
+      header: true,
+      complete: function(results) {
+        console.log(results);
+        makeGrid(results);
+      }
+    });
+    {% else %}
     Papa.parse("{{ json["catalog_file"] | safe }}", {
       download: true,
       header: true,
@@ -19,6 +28,7 @@
         makeGrid(results);
       }
     });
+    {% endif %}
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
By default, ESM collections look for a CSV file to populate the table for their endpoint; this adds some additional JavaScript to populate the table using an ESM collection's DataFrame object if this CSV file doesn't exist already (in the case of a single file catalog).