### PR TITLE
First pass at adding GitHub actions

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,14 +1,5 @@
-# This file specifies files that are *not* uploaded to Google Cloud Platform
-# using gcloud. It follows the same syntax as .gitignore, with the addition of
-# "#!include" directives (which insert the entries of the given .gitignore-style
-# file at that point).
-#
-# For more information, run:
-#   $ gcloud topic gcloudignore
-#
 .gcloudignore
-# If you would like to upload your .git directory, .gitignore file or files
-# from your .gitignore file, remove the corresponding line
-# below:
 .git
+.github
 .gitignore
+README.md

--- a/.github/workflows/app-engine.yml
+++ b/.github/workflows/app-engine.yml
@@ -1,0 +1,42 @@
+# Copyright 2020 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Deploy to Google App Engine
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  setup-build-deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Setup and configure gcloud CLI
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '286.0.0'
+          project_id: ${{ secrets.PROJECT_ID }}
+          service_account_email: ${{ secrets.SA_EMAIL }}
+          service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+
+      # Deploy App to App Engine
+      - name: Deploy
+        run: |
+          gcloud app deploy


### PR DESCRIPTION
This is an attempt to move the deployment of this app from Cloud Build to GitHub actions using [this workflow](https://github.com/GoogleCloudPlatform/github-actions/tree/master/example-workflows/gae); if this works properly then we may be able to use a variation of Cloud Platform's GitHub actions to fix the CI on [pangeo-datastore](https://github.com/pangeo-data/pangeo-datastore).