### PR TITLE
Adjust intake attribute access to avoid unnecessary dataset loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,8 +63,8 @@ def browse(path):
         if len(items) == 1:
             crumbs = ['<li class="active">%s</li>' % cat.name]
             return render_template('catalog.html', cat=cat, crumbs=crumbs, path=path,
-                                   catalogs=any([cat[item].container == 'catalog' for item in cat]),
-                                   datasets=any([cat[item].container in ['dataframe', 'xarray'] for item in cat]))
+                                   catalogs=any([cat[item]._container == 'catalog' for item in cat]),
+                                   datasets=any([cat[item]._container in ['dataframe', 'xarray'] for item in cat]))
         else:
             crumbs = ['<li><a href="%s">%s</a></li>' %
                     (url_for('browse', path='/'.join(items[0:1])), cat.name)]
@@ -77,21 +77,21 @@ def browse(path):
             else:
                 crumbs.append('<li class="active">%s</li>' % item)
         # intake catalogs
-        if cat.container == 'catalog':
+        if cat._container == 'catalog':
             return render_template('catalog.html', cat=cat, crumbs=crumbs, path=path,
-                                   catalogs=any([cat[item].container == 'catalog' for item in cat]),
-                                   datasets=any([cat[item].container in ['dataframe', 'xarray'] for item in cat]))
+                                   catalogs=any([cat[item]._container == 'catalog' for item in cat]),
+                                   datasets=any([cat[item]._container in ['dataframe', 'xarray'] for item in cat]))
         # intake-esm collections
         elif cat._driver == 'intake_esm.esm_datastore':
-            r = requests.get(cat.esmcol_path)
+            r = requests.get(cat._captured_init_kwargs['args']['esmcol_obj'])
             return render_template('esmcol.html', cat=cat, crumbs=crumbs, json=r.json())
         # anything that can be handled with `to_dask()`
-        elif cat.container in ['dataframe', 'xarray']:
+        elif cat._container in ['dataframe', 'xarray']:
             return render_template('dask.html', cat=cat, crumbs=crumbs)
         # generic error for anything else
         else:
             raise NotImplementedError('This type of dataset is not recognized: %s, %s' %
-                                     (cat.container, cat._driver))
+                                     (cat._container, cat._driver))
     except:
         type, value = sys.exc_info()[:2]
         return render_template('error.html', type=type, value=value), 500

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -25,10 +25,10 @@ list(cat)</code></pre>
     <h3>Child Catalogs</h3>
     <div class="list-group">
       {% for item in cat|sort %}
-      {% if cat[item].container == "catalog" %}
+      {% if cat[item]._container == "catalog" %}
       <a href="{{ url_for('browse', path='%s/%s' % (path, item)) }}" class="list-group-item">
         <h4>{{ item }}</h4>
-        <p class="description">{{ cat[item].description }}</p>
+        <p class="description">{{ cat[item]._description }}</p>
       </a>
       {% endif %}
       {% endfor %}
@@ -39,10 +39,10 @@ list(cat)</code></pre>
     <h3>Datasets</h3>
     <div class="list-group">
       {% for item in cat|sort %}
-      {% if cat[item].container in ["xarray", "dataframe"] %}
+      {% if cat[item]._container in ["xarray", "dataframe"] %}
       <a href="{{ url_for('browse', path='%s/%s' % (path, item)) }}" class="list-group-item">
         <h4>{{ item }}</h4>
-        <p class="description">{{ cat[item].description }}</p>
+        <p class="description">{{ cat[item]._description }}</p>
       </a>
       {% endif %}
       {% endfor %}

--- a/templates/dask.html
+++ b/templates/dask.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}{{ cat.description }}{% endblock %}
+{% block title %}{{ cat._description }}{% endblock %}
 
 {% block content %}
 <main role="main" class="container">
-  <h1>{{ cat.name }}</h1>
+  <h1>{{ cat._name }}</h1>
   <div>
     <ol class="breadcrumb">
       {% for crumb in crumbs %}
@@ -14,20 +14,20 @@
   </div>
 
   <div class="info">
-    <h2>{{ cat.description }}</h2>
+    <h2>{{ cat._description }}</h2>
 
     <h3>Load in Python</h3>
     <pre><code class="language-python">from intake import open_catalog<br>
 cat = open_catalog("{{ cat.catalog_object.path }}")
-ds  = cat["{{ cat.name }}"].to_dask()</code></pre>
+ds  = cat["{{ cat._name }}"].to_dask()</code></pre>
 
     <h3>Metadata</h3>
     <table class="table table-condensed table-hover">
       <tbody>
-        {% for data in cat.metadata %}
+        {% for data in cat._metadata %}
         <tr>
           <td>{{ data }}</td>
-          <td>{{ cat.metadata[data] }}</td>
+          <td>{{ cat._metadata[data] }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -37,9 +37,9 @@ ds  = cat["{{ cat.name }}"].to_dask()</code></pre>
   <div class="xarray">
     <h3>Dataset Contents</h3>
     <div class="xarray-repr">
-      {% if cat.container == "dataframe" %}
+      {% if cat._container == "dataframe" %}
       {{ cat.to_dask().to_html() | safe }}
-      {% elif cat.container == "xarray" %}
+      {% elif cat._container == "xarray" %}
       {{ cat.to_dask()._repr_html_() | safe }}
       {% endif %}
     </div>

--- a/templates/esmcol.html
+++ b/templates/esmcol.html
@@ -41,11 +41,11 @@
 <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css">
 {% endblock %}
 
-{% block title %}{{ cat.description }}{% endblock %}
+{% block title %}{{ cat._description }}{% endblock %}
 
 {% block content %}
 <main role="main" class="container">
-  <h1>{{ cat.name }}</h1>
+  <h1>{{ cat._name }}</h1>
   <div>
     <ol class="breadcrumb">
       {% for crumb in crumbs %}
@@ -55,12 +55,12 @@
   </div>
   <div class="info">
 
-    <h2>{{ cat.description }}</h2>
+    <h2>{{ cat._description }}</h2>
 
     <h3>Load in Python</h3>
     <pre><code class="language-python">from intake import open_catalog<br>
 cat = open_catalog("{{ cat.catalog_object.path }}")
-ds  = cat.{{ cat.name }}()</code></pre>
+ds  = cat.{{ cat._name }}()</code></pre>
 
     <h3>Metadata</h3>
     <pre id="json-renderer"></pre>


### PR DESCRIPTION
After looking into slow load times on [the climate catalog](https://catalog.pangeo.io/browse/master/climate/), I found that the way I was calling attributes for a catalog entry

```
cat[item].attribute
``` 

was forcing the entry to perform an unnecessary reload to find the attribute, versus

```
cat[item]._attribute
```

Which effectively fetches the attribute from a dictionary instantly. This makes a huge difference for ESM collections in particular, but should boost performance across any pages that were trying to get attributes from data sources.